### PR TITLE
PLIP 20239: Behavior name in ZCML directive, registration lookup utility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -138,8 +138,8 @@ The directive supports the attributes:
     Convenience lookup name for this behavior (optional).
     The behavior will be always registered under the dotted name of ``provides`` attribute.
     This are usally long names. ``name`` is a short name for this.
-    If ``name`` is given it is registered additional with the name.
-    Anyway using short namespaces in ``name `` is recommended.
+    If ``name`` is given the behavior is registered additional under it.
+    Anyway using short namespaces in ``name`` is recommended.
 
 ``marker``
     A marker interface to be applied by the behavior.

--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,7 @@ The simplest way to do that is to load the ``meta.zcml`` file from this package 
       <include package="plone.behavior" file="meta.zcml" />
 
       <plone:behavior
+          name="locking_support"
           title="Locking support"
           description="Optional object-level locking"
           provides=".interfaces.ILockingSupport"

--- a/README.rst
+++ b/README.rst
@@ -89,6 +89,20 @@ After this is done you can adapt a context to ``ILockingSupport`` as normal::
     if locking is not None:
         locking.lock()
 
+The ``name`` is can be used for lookup instead of the full dotted name of the interface::
+
+    from plone.behavior.interfaces import IBehavior
+    from zope.component import getUtility
+
+    registration = getUtility(IBehavior, name='locking_support')
+
+We also have a helper function to achieve this::
+
+    from registration import lookup_behavior_registration
+
+    registration = lookup_behavior_registration(name='locking_support')
+
+
 You'll get an instance of ``LockingSupport`` if context can be adapted to ``IBehaviorAssignable`` (which, recall, is application specific),
 and if the implementation of ``IBehaviorAssignable`` says that this context supports this particular behavior.
 
@@ -120,6 +134,13 @@ The directive supports the attributes:
     An interface to which the behavior can be adapted.
     This is what the conditional adapter factory will be registered as providing (required).
 
+``name``
+    Convenience lookup name for this behavior (optional).
+    The behavior will be always registered under the dotted name of ``provides`` attribute.
+    This are usally long names. ``name`` is a short name for this.
+    If ``name`` is given it is registered additional with the name.
+    Anyway using short namespaces in ``name `` is recommended.
+
 ``marker``
     A marker interface to be applied by the behavior.
     If ``factory`` is not given, then this is optional and defaults to the value of ``provides``.
@@ -133,7 +154,6 @@ The directive supports the attributes:
     ``ISchemaAwareFactory`` is an interface for factories that should be initialised with a schema.
     It is called with the value given in ``provides`` as the only argument.
     The value returned is then used as the factory, another callable that can create appropriate behavior factories on demand.
-
 
 ``for``
     The type of object to register the conditional adapter factory for (optional).
@@ -155,7 +175,8 @@ Example usage, given
 - some ``typed_context`` (some arbitary object) which is ``IBehaviorAssignable`` and provides ``IMyType``,
 - an ``MyTypedFactory`` class implementing ``IMyBehavior`` and adapting ``IMyType``,
 
-Title and description is trivial, so we dont cover it here in the explanantion.
+``title`` and ``description`` is trivial, so we dont cover it here in the explanantion.
+We dont cover ``name`` too, because it's not having any effect in this usage.
 To simplify it, we assume ``context`` ``IBehaviorAssignable`` always supports the behavior.
 Also for simplifications sake we assume some magic applies the marker interface to ``context``
 I.e. both is done by ``plone.dexterity``.

--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ After this is done you can adapt a context to ``ILockingSupport`` as normal::
     if locking is not None:
         locking.lock()
 
-The ``name`` is can be used for lookup instead of the full dotted name of the interface::
+The ``name`` can be used for lookup instead of the full dotted name of the interface::
 
     from plone.behavior.interfaces import IBehavior
     from zope.component import getUtility

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -2,21 +2,23 @@
 Changelog
 =========
 
-1.0.4 (unreleased)
-------------------
+1.1 (unreleased)
+----------------
+
+* Add name to behavior directive. This name can be used to lookup behavior
+  registrations by new plone.behaviors.registration.lookup_behavior function.
+  [rnixx]
 
 - Added more documentation, simplified code in directive, added a warning if
   ``for`` is given w/o ``factory``.
   [jensens]
 
-
 1.0.3 (2015-04-29)
 ------------------
 
-- Code modernization: utf-header, pep8, rst-files, adapter/implementer
+* Code modernization: utf-header, pep8, rst-files, adapter/implementer
   decorators, ...
   [jensens]
-
 
 1.0.2 (2013-01-17)
 ------------------

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -6,7 +6,8 @@ Changelog
 ----------------
 
 * Add name to behavior directive. This name can be used to lookup behavior
-  registrations by new plone.behaviors.registration.lookup_behavior function.
+  registrations by
+  new plone.behaviors.registration.lookup_behavior_registration function.
   [rnixx]
 
 - Added more documentation, simplified code in directive, added a warning if

--- a/plone/behavior/__init__.py
+++ b/plone/behavior/__init__.py
@@ -1,3 +1,7 @@
 # -*- coding: utf-8 -*-
 # Convenience import
 from plone.behavior.annotation import AnnotationStorage  # noqa
+import logging
+
+
+logger = logging.getLogger('plone.behavior')

--- a/plone/behavior/directives.rst
+++ b/plone/behavior/directives.rst
@@ -101,8 +101,13 @@ With this in place, the behaviors should be registered, e.g:
 
     >>> from plone.behavior.interfaces import IBehavior
     >>> sorted([u for u in sm.registeredUtilities() if u.name == u"plone.behavior.tests.IAdapterBehavior"]) # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
-    [UtilityRegistration(..., IBehavior, 'plone.behavior.tests.IAdapterBehavior', <BehaviorRegistration for plone.behavior.tests.IAdapterBehavior>,...),
-     UtilityRegistration(..., IInterface, 'plone.behavior.tests.IAdapterBehavior', IAdapterBehavior,...)]
+    [UtilityRegistration(<BaseGlobalComponents base>, IBehavior, 'plone.behavior.tests.IAdapterBehavior', <BehaviorRegistration adapter_behavior at ...
+      schema: plone.behavior.tests.IAdapterBehavior
+      marker: (no marker is set)
+      factory: <class 'plone.behavior.tests.AdapterBehavior'>
+      title: Adapter behavior
+      A basic adapter behavior
+    >, None, u''), UtilityRegistration(<BaseGlobalComponents base>, IInterface, 'plone.behavior.tests.IAdapterBehavior', IAdapterBehavior, None, '')]
 
     >>> from plone.behavior.tests import IAdapterBehavior
     >>> [a for a in sm.registeredAdapters() if a.provided == IAdapterBehavior]  # doctest: +ELLIPSIS
@@ -278,10 +283,22 @@ Test registration lookup helper utility.
       ...
     BehaviorRegistrationNotFound: inexistent
 
-    >>> lookup_behavior_registration('adapter_behavior')
-    <BehaviorRegistration for plone.behavior.tests.IAdapterBehavior>
+    >>> lookup_behavior_registration('adapter_behavior')  # doctest: +ELLIPSIS
+    <BehaviorRegistration adapter_behavior at ...
+      schema: plone.behavior.tests.IAdapterBehavior
+      marker: (no marker is set)
+      factory: <class 'plone.behavior.tests.AdapterBehavior'>
+      title: Adapter behavior
+      A basic adapter behavior
+    >
 
     >>> lookup_behavior_registration(
     ...     identifier='plone.behavior.tests.IAdapterBehavior'
-    ... )
-    <BehaviorRegistration for plone.behavior.tests.IAdapterBehavior>
+    ... )  # doctest: +ELLIPSIS
+    <BehaviorRegistration adapter_behavior at ...
+      schema: plone.behavior.tests.IAdapterBehavior
+      marker: (no marker is set)
+      factory: <class 'plone.behavior.tests.AdapterBehavior'>
+      title: Adapter behavior
+      A basic adapter behavior
+    >

--- a/plone/behavior/directives.rst
+++ b/plone/behavior/directives.rst
@@ -31,6 +31,7 @@ plone.behavior.tests:
     ...     <include package="plone.behavior" file="meta.zcml" />
     ...
     ...     <plone:behavior
+    ...         name="adapter_behavior"
     ...         title="Adapter behavior"
     ...         description="A basic adapter behavior"
     ...         provides=".tests.IAdapterBehavior"
@@ -38,6 +39,7 @@ plone.behavior.tests:
     ...         />
     ...
     ...     <plone:behavior
+    ...         name="context_restricted_behavior"
     ...         title="Context restricted behavior"
     ...         provides=".tests.IRestrictedAdapterBehavior"
     ...         factory=".tests.RestrictedAdapterBehavior"
@@ -45,23 +47,27 @@ plone.behavior.tests:
     ...         />
     ...
     ...     <plone:behavior
+    ...         name="factory_implied_context_restricted_behavior"
     ...         title="Factory-implied context restricted behavior"
     ...         provides=".tests.IImpliedRestrictionAdapterBehavior"
     ...         factory=".tests.ImpliedRestrictionAdapterBehavior"
     ...         />
     ...
     ...     <plone:behavior
+    ...         name="marker_interface_behavior"
     ...         title="Marker interface behavior"
     ...         provides=".tests.IMarkerBehavior"
     ...         />
     ...
     ...     <plone:behavior
+    ...         name="annotation_storage_behavior"
     ...         title="Annotation storage behavior"
     ...         provides=".tests.IAnnotationStored"
     ...         factory="plone.behavior.AnnotationStorage"
     ...         />
     ...
     ...     <plone:behavior
+    ...         name="marker_and_adapter"
     ...         title="Marker and adapter"
     ...         provides=".tests.IMarkerAndAdapterBehavior"
     ...         factory="plone.behavior.AnnotationStorage"
@@ -111,6 +117,9 @@ Let us test the various utilities and the underlying adapters more carefully.
 for any context.
 
     >>> dummy = getUtility(IBehavior, name=u"plone.behavior.tests.IAdapterBehavior")
+    >>> dummy.name
+    u'adapter_behavior'
+
     >>> dummy.title
     u'Adapter behavior'
 
@@ -133,6 +142,9 @@ for any context.
 2) An adapter behavior with a factory and an explicit context restriction.
 
     >>> dummy = getUtility(IBehavior, name=u"plone.behavior.tests.IRestrictedAdapterBehavior")
+    >>> dummy.name
+    u'context_restricted_behavior'
+
     >>> dummy.title
     u'Context restricted behavior'
 
@@ -156,6 +168,9 @@ for any context.
 declaration on the factory.
 
     >>> dummy = getUtility(IBehavior, name=u"plone.behavior.tests.IImpliedRestrictionAdapterBehavior")
+    >>> dummy.name
+    u'factory_implied_context_restricted_behavior'
+
     >>> dummy.title
     u'Factory-implied context restricted behavior'
 
@@ -178,6 +193,9 @@ declaration on the factory.
 4) A behavior with a marker marker interface.
 
     >>> dummy = getUtility(IBehavior, name=u"plone.behavior.tests.IMarkerBehavior")
+    >>> dummy.name
+    u'marker_interface_behavior'
+
     >>> dummy.title
     u'Marker interface behavior'
 
@@ -200,6 +218,9 @@ declaration on the factory.
 5) A behavior using the standard annotation factory
 
     >>> dummy = getUtility(IBehavior, name=u"plone.behavior.tests.IAnnotationStored")
+    >>> dummy.name
+    u'annotation_storage_behavior'
+
     >>> dummy.title
     u'Annotation storage behavior'
 
@@ -222,6 +243,9 @@ declaration on the factory.
 6) A behavior providing a marker interface and using an adapter factory.
 
     >>> dummy = getUtility(IBehavior, name=u"plone.behavior.tests.IMarkerAndAdapterBehavior")
+    >>> dummy.name
+    u'marker_and_adapter'
+
     >>> dummy.title
     u'Marker and adapter'
 
@@ -240,3 +264,22 @@ declaration on the factory.
     >>> from plone.behavior.tests import IMarkerAndAdapterBehavior
     >>> [a.required for a in sm.registeredAdapters() if a.provided == IMarkerAndAdapterBehavior][0]
     (<InterfaceClass zope.annotation.interfaces.IAnnotatable>,)
+
+Test registration lookup helper utility.
+
+    >>> from plone.behavior.registration import lookup_behavior
+    >>> lookup_behavior()
+    Traceback (most recent call last):
+      ...
+    ValueError: Either ``name`` or ``identifier`` must be given
+
+    >>> lookup_behavior('inexistent')
+    Traceback (most recent call last):
+      ...
+    BehaviorRegistrationNotFound: inexistent
+
+    >>> lookup_behavior('adapter_behavior')
+    <BehaviorRegistration for plone.behavior.tests.IAdapterBehavior>
+
+    >>> lookup_behavior(identifier='plone.behavior.tests.IAdapterBehavior')
+    <BehaviorRegistration for plone.behavior.tests.IAdapterBehavior>

--- a/plone/behavior/directives.rst
+++ b/plone/behavior/directives.rst
@@ -267,19 +267,21 @@ declaration on the factory.
 
 Test registration lookup helper utility.
 
-    >>> from plone.behavior.registration import lookup_behavior
-    >>> lookup_behavior()
+    >>> from plone.behavior.registration import lookup_behavior_registration
+    >>> lookup_behavior_registration()
     Traceback (most recent call last):
       ...
     ValueError: Either ``name`` or ``identifier`` must be given
 
-    >>> lookup_behavior('inexistent')
+    >>> lookup_behavior_registration('inexistent')
     Traceback (most recent call last):
       ...
     BehaviorRegistrationNotFound: inexistent
 
-    >>> lookup_behavior('adapter_behavior')
+    >>> lookup_behavior_registration('adapter_behavior')
     <BehaviorRegistration for plone.behavior.tests.IAdapterBehavior>
 
-    >>> lookup_behavior(identifier='plone.behavior.tests.IAdapterBehavior')
+    >>> lookup_behavior_registration(
+    ...     identifier='plone.behavior.tests.IAdapterBehavior'
+    ... )
     <BehaviorRegistration for plone.behavior.tests.IAdapterBehavior>

--- a/plone/behavior/metaconfigure.py
+++ b/plone/behavior/metaconfigure.py
@@ -78,10 +78,6 @@ def behaviorDirective(_context, title, provides, name=None, description=None,
     if factory is not None and ISchemaAwareFactory.providedBy(factory):
         factory = factory(provides)
 
-    # if no name is given take the dotted path given as identifier
-    if name is None:
-        name = provides.__identifier__
-
     registration = BehaviorRegistration(
         title=title,
         description=description,
@@ -95,9 +91,18 @@ def behaviorDirective(_context, title, provides, name=None, description=None,
     utility(
         _context,
         provides=IBehavior,
-        name=name,
+        name=provides.__identifier__,
         component=registration
     )
+
+    if name is not None:
+        # for convinience we register with a given name
+        utility(
+            _context,
+            provides=IBehavior,
+            name=name,
+            component=registration
+        )
 
     if factory is None:
         if for_ is not None:

--- a/plone/behavior/registration.py
+++ b/plone/behavior/registration.py
@@ -28,7 +28,7 @@ class BehaviorRegistrationNotFound(Exception):
     """
 
 
-def lookup_behavior(name=None, identifier=None):
+def lookup_behavior_registration(name=None, identifier=None):
     """Lookup behavior registration either by name or interface identifier.
 
     ``ValueError`` is thrown if function call is incomplete.

--- a/plone/behavior/registration.py
+++ b/plone/behavior/registration.py
@@ -1,19 +1,47 @@
 # -*- coding: utf-8 -*-
 from plone.behavior.interfaces import IBehavior
 from zope.interface import implementer
+from zope.component import getUtility
+from zope.component import ComponentLookupError
 
 
 @implementer(IBehavior)
 class BehaviorRegistration(object):
 
-    def __init__(self, title, description, interface, marker, factory):
+    def __init__(self, title, description, interface,
+                 marker, factory, name=None):
         self.title = title
         self.description = description
         self.interface = interface
         self.marker = marker
         self.factory = factory
+        self.name = name
 
     def __repr__(self):
         return "<BehaviorRegistration for {0}>".format(
             self.interface.__identifier__
         )
+
+
+class BehaviorRegistrationNotFound(Exception):
+    """Exception thrown if behavior registration lookup fails.
+    """
+
+
+def lookup_behavior(name=None, identifier=None):
+    """Lookup behavior registration either by name or interface identifier.
+
+    ``ValueError`` is thrown if function call is incomplete.
+    ``BehaviorRegistrationNotFound`` is thrown if lookup fails.
+    """
+    try:
+        assert(name or identifier)
+    except AssertionError:
+        raise ValueError('Either ``name`` or ``identifier`` must be given')
+    # identifier rules if given
+    if identifier:
+        name = identifier
+    try:
+        return getUtility(IBehavior, name=name)
+    except ComponentLookupError:
+        raise BehaviorRegistrationNotFound(name)

--- a/plone/behavior/registration.py
+++ b/plone/behavior/registration.py
@@ -4,6 +4,17 @@ from zope.interface import implementer
 from zope.component import getUtility
 from zope.component import ComponentLookupError
 
+import textwrap
+
+REGISTRATION_REPR = """\
+<{class} {name} at {id}
+  schema: {identifier}
+  marker: {marker}
+  factory: {factory}
+  title: {title}
+  {description}
+>"""
+
 
 @implementer(IBehavior)
 class BehaviorRegistration(object):
@@ -18,9 +29,26 @@ class BehaviorRegistration(object):
         self.name = name
 
     def __repr__(self):
-        return "<BehaviorRegistration for {0}>".format(
-            self.interface.__identifier__
-        )
+        if self.marker is not None:
+            marker_info = self.marker.__identifier__
+        elif self.marker is not None and self.marker is not self.interface:
+            marker_info = '(uses schema as marker)'
+        else:
+            marker_info = '(no marker is set)'
+        info = {
+            'class': self.__class__.__name__,
+            'id': id(self),
+            'name': self.name or '(unique name not set)',
+            'identifier': self.interface.__identifier__,
+            'marker': marker_info,
+            'factory': unicode(self.factory),
+            'title': self.title or '(no title)',
+            'description': textwrap.fill(
+                self.description or '(no description)',
+                subsequent_indent='  '
+            )
+        }
+        return REGISTRATION_REPR.format(**info)
 
 
 class BehaviorRegistrationNotFound(Exception):

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     keywords='Plone behavior registry',
     author='Martin Aspeli',
     author_email='optilude@gmail.com',
-    url='http://code.google.com/p/dexterity',
+    url='http://pypi.python.org/pypi/plone.dexterity',
     license='BSD',
     packages=find_packages(exclude=['ez_setup']),
     namespace_packages=['plone'],
@@ -33,11 +33,11 @@ setup(
     zip_safe=False,
     install_requires=[
         'setuptools',
+        'zope.annotation',
         'zope.component',
+        'zope.configuration',
         'zope.interface',
         'zope.schema',
-        'zope.annotation',
-        'zope.configuration',
     ],
     extras_require={
         'test': [],


### PR DESCRIPTION
According to http://comments.gmane.org/gmane.comp.web.zope.plone.devel/34834 this pull request introduces behavior short names which are set at ZCML registration time and should later be used for behavior lookup on dexterity content and for behavior introspection.

This change is 100% B/C and only logs a warning at instance startup if a behavior registration has no name set.

More to come in downstream packages

cheers