### PR TITLE
Register behavior only by it's short name and not by dotted name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-1.1.2 (unreleased)
+1.2.0 (unreleased)
 ------------------
 
 Incompatibilities:
@@ -11,7 +11,9 @@ Incompatibilities:
 
 New:
 
-- *add item here*
+- New option to register a behavior only by it's short name and not by it's dotted name.
+  This enables more advanced behavior subclassing capabilities.
+  [jensens]
 
 Fixes:
 

--- a/README.rst
+++ b/README.rst
@@ -2,11 +2,20 @@
 plone.behavior
 ==============
 
+.. contents:: Table of Contents
+   :depth: 2
+
+
+Overview
+========
+
 This package provides support for **behaviors**.
-A behavior is a re-usable aspect of an object that can be enabled or disabled without changing the component registry.
+
+    A behavior is a re-usable aspect of an object that can be enabled or disabled without changing the component registry.
 
 A behavior is described by an interface, and has metadata such as a title and a description.
-The dotted name of the interface is the unique name for the behavior, from which the metadata can be looked up.
+The behavior can be looked up by a given short name or by the dotted name of the interface.
+With this unique name behaviors metadata can be looked up.
 When the behavior is enabled for an object, you will be able to adapt the object to the interface.
 In some cases, the interface can be used as a marker interface as well.
 
@@ -14,25 +23,30 @@ As an example, let's say that your application needs to support object-level loc
 This can be modeled via an adapter, but you want to leave it until runtime to determine whether locking is enabled for a particular object.
 You could then register locking as a behavior.
 
-Requirements
-------------
+**Requirements and Limitations:**
 
-This package comes with support for registering behaviors and factories.
-It does not, however, implement the policy for determining what behaviors are enabled on a particular object at a particular time.
-That decision is deferred to an ``IBehaviorAssignable`` adapter, which must be implemented (``plone.dexterity`` implements this).
+* This package comes with support for registering behaviors and factories.
 
-This package also does not directly support the adding of marker interfaces to instances.
-To do that, you can either use an event handler to mark an object when it is created, or a dynamic __providedBy__ descriptor that does the lookup on the fly (but you probably want some caching).
+* It does not implement the policy for determining what behaviors are enabled on a particular object at a particular time.
+  That decision is deferred to an ``IBehaviorAssignable`` adapter, which must be implemented (``plone.dexterity`` implements this).
 
-The intention is that behavior assignment is generic across an application, used for multiple, optional behaviors.
-It probably doesn't make much sense to use ``plone.behavior`` for a single type of object.
-The means to keep track of which behaviors are enabled for what types of objects will be application specific.
+* Like the ``IBehaviorAssignable`` plumbing, marker interface support needs to be enabled on a per-application basis.
+  This package also does not directly support the adding of marker interfaces to instances.
+  To do that, you can either use an event handler to mark an object when it is created, or a dynamic __providedBy__ descriptor that does the lookup on the fly (but you probably want some caching).
+  A sample event handler is provided with this package, but is not registered by default
+
+* The intention is that behavior assignment is generic across an application, used for multiple, optional behaviors.
+  It probably doesn't make much sense to use ``plone.behavior`` for a single type of object.
+  The means to keep track of which behaviors are enabled for what types of objects will be application specific.
 
 Usage
------
+=====
 
-A behavior is written much like an adapter, except that you don't specify
-the type of context being adapted directly. For example::
+Explained
+---------
+
+A behavior is written much like an adapter, except that you don't specify the type of context being adapted directly.
+For example::
 
     from zope.interface import Interface
     from zope.interface import implementer
@@ -108,11 +122,7 @@ and if the implementation of ``IBehaviorAssignable`` says that this context supp
 
 It is also possible to let the provided interface act as a marker interface that is to be provided directly by the instance.
 To achieve this, omit the ``factory`` argument.
-This is useful if you need to register other adapters (including views and viewlets) for instances providing a particular behavior.
-
-Like the IBehaviorAssignable plumbing, marker interface support needs to be enabled on a per-application basis.
-It can be done with a custom __providedBy__ decorator or an IObjectCreatedEvent handler for applying the marker.
-A sample event handler is provided with this package, but is not registered by default
+This is useful if you need to register other adapters for instances providing a particular behavior.
 
 ZCML Reference
 --------------
@@ -141,6 +151,11 @@ The directive supports the attributes:
     If ``name`` is given the behavior is registered additional under it.
     Anyway using short namespaces in ``name`` is recommended.
 
+``name_only``
+    If set to ``yes`` or ``true`` the behavior is registered only under the given name,
+    but not under the dotted path of the ``provides`` interface.
+    This makes ``name`` mandatory.
+
 ``marker``
     A marker interface to be applied by the behavior.
     If ``factory`` is not given, then this is optional and defaults to the value of ``provides``.
@@ -163,6 +178,9 @@ The directive supports the attributes:
 
     Must be one element (no multiadapters, applies also for auto-detection).
 
+
+ZCML Examples
+-------------
 
 Example usage, given
 
@@ -269,3 +287,11 @@ Further Reading
 ---------------
 
 For more details please read the doctests in the source code: ``behavior.rst``, ``directives.rst`` and ``annotation.rst``.
+
+
+Source Code
+===========
+
+Contributors please read the document `Process for Plone core's development <http://docs.plone.org/develop/plone-coredev/index.html>`_
+
+Sources are at the `Plone code repository hosted at Github <https://github.com/plone/plone.behavior>`_.

--- a/plone/behavior/directives.rst
+++ b/plone/behavior/directives.rst
@@ -21,6 +21,10 @@ plone.behavior.tests:
 
   * A behavior providing a marker interface and using an adapter factory.
 
+  * A behavior registered by name only
+
+::
+
     >>> configuration = """\
     ... <configure
     ...      package="plone.behavior"
@@ -72,6 +76,13 @@ plone.behavior.tests:
     ...         provides=".tests.IMarkerAndAdapterBehavior"
     ...         factory="plone.behavior.AnnotationStorage"
     ...         marker=".tests.IMarkerAndAdapterMarker"
+    ...         />
+    ...
+    ...     <plone:behavior
+    ...         name="name_only"
+    ...         name_only="yes"
+    ...         title="Marker interface behavior"
+    ...         provides=".tests.INameOnlyBehavior"
     ...         />
     ...
     ... </configure>
@@ -269,6 +280,22 @@ declaration on the factory.
     >>> from plone.behavior.tests import IMarkerAndAdapterBehavior
     >>> [a.required for a in sm.registeredAdapters() if a.provided == IMarkerAndAdapterBehavior][0]
     (<InterfaceClass zope.annotation.interfaces.IAnnotatable>,)
+
+7) A name only registered behavior
+
+    >>> from zope.component.interfaces import ComponentLookupError
+    >>> failed = False
+    >>> try:
+    ...     dummy = getUtility(IBehavior, name=u"plone.behavior.tests.INameOnlyBehavior")
+    ... except ComponentLookupError, e:
+    ...     failed = True
+    >>> failed
+    True
+
+    >>> dummy = getUtility(IBehavior, name=u"name_only")
+    >>> dummy.name
+    u'name_only'
+
 
 Test registration lookup helper utility.
 

--- a/plone/behavior/metaconfigure.py
+++ b/plone/behavior/metaconfigure.py
@@ -61,9 +61,17 @@ class IBehaviorDirective(Interface):
                     u"factory for zope.interface.Interface",
         required=False)
 
+    name_only = configuration_fields.Bool(
+        title=u"Do not register the behavior under the dotted path, but "
+              u"only under the given name",
+        description=u"Use this option to register a behavior for the same "
+                    u"provides under a different name.",
+        required=False)
+
 
 def behaviorDirective(_context, title, provides, name=None, description=None,
-                      marker=None, factory=None, for_=None):
+                      marker=None, factory=None, for_=None, name_only=False):
+
     if marker is None and factory is None:
         marker = provides
 
@@ -71,6 +79,10 @@ def behaviorDirective(_context, title, provides, name=None, description=None,
         raise ConfigurationError(
             u"You cannot specify a different 'marker' and 'provides' if "
             u"there is no adapter factory for the provided interface."
+        )
+    if name_only and name is None:
+        raise ConfigurationError(
+            u"If you decide to only register by 'name', a name must be given."
         )
 
     # Instantiate the real factory if it's the schema-aware type. We do
@@ -86,14 +98,14 @@ def behaviorDirective(_context, title, provides, name=None, description=None,
         factory=factory,
         name=name,
     )
-
-    # behavior registration by provides interface identifier
-    utility(
-        _context,
-        provides=IBehavior,
-        name=provides.__identifier__,
-        component=registration
-    )
+    if not name_only:
+        # behavior registration by provides interface identifier
+        utility(
+            _context,
+            provides=IBehavior,
+            name=provides.__identifier__,
+            component=registration
+        )
 
     if name is not None:
         # for convinience we register with a given name

--- a/plone/behavior/tests.py
+++ b/plone/behavior/tests.py
@@ -57,6 +57,11 @@ class IMarkerBehavior(Interface):
     pass
 
 
+# Behavior to be registered with name only
+class INameOnlyBehavior(Interface):
+    pass
+
+
 # For test of the annotation factory
 class IAnnotationStored(Interface):
     some_field = schema.TextLine(title=u"Some field", default=u"default value")
@@ -86,6 +91,6 @@ def test_suite():
         doctest.DocFileSuite(
             'annotation.rst',
             setUp=zope.component.testing.setUp,
-            tearDown=zope.component.testing.tearDown),
-        )
-    )
+            tearDown=zope.component.testing.tearDown
+        ),
+    ))


### PR DESCRIPTION
At the moment one cant register a sub classed behavior under a different name, even if the use case is completely valid. Problem is, that even if a different name was given the behavior utility would be registered a second time under its dotted path. 

With this change this is possible adding the limitation, that the dotted path can not be used for behavior lookup with the newly registered sub classed behavior. However, in general the dotted path is not needed any more.