### PR TITLE
in zcml, if a marker is given, but no for, use marker as for.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-1.1.5 (unreleased)
+1.2.0 (unreleased)
 ------------------
 
 Breaking changes:
@@ -10,11 +10,16 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- For zcml registration:
+  If both, no ``for`` and no ``@adapter`` is given,
+  fall first back to ``marker`` if given (new),
+  else to ``Interface`` (as it was already before).
+  [jensens]
 
 Bug fixes:
 
-- *add item here*
+- Cleanup: Make Jenkins CI code analysis silent by fixing the issues.
+  [jensens]
 
 
 1.1.4 (2016-12-06)

--- a/plone/behavior/directives.rst
+++ b/plone/behavior/directives.rst
@@ -79,6 +79,14 @@ plone.behavior.tests:
     ...         />
     ...
     ...     <plone:behavior
+    ...         name="marker_and_adapter_no_atadapter"
+    ...         title="Marker and adapter no @adapter"
+    ...         provides=".tests.IMarkerAndAdapterBehavior2"
+    ...         factory=".tests.DummyBehaviorImpl"
+    ...         marker=".tests.IMarkerAndAdapterMarker2"
+    ...         />
+    ...
+    ...     <plone:behavior
     ...         name="name_only"
     ...         name_only="yes"
     ...         title="Marker interface behavior"
@@ -261,6 +269,8 @@ declaration on the factory.
 
 6) A behavior providing a marker interface and using an adapter factory.
 
+6.1) ``@adapter`` decorated Behavior implementation.
+
     >>> dummy = getUtility(IBehavior, name=u"plone.behavior.tests.IMarkerAndAdapterBehavior")
     >>> dummy.name
     u'marker_and_adapter'
@@ -280,9 +290,40 @@ declaration on the factory.
     >>> dummy.factory # doctest: +ELLIPSIS
     <plone.behavior.annotation.AnnotationStorage object at ...>
 
+    The factory has ist ``__component_adapts__`` (``@adapter``) in place, so the adapted Interface must be returned.
+
     >>> from plone.behavior.tests import IMarkerAndAdapterBehavior
     >>> [a.required for a in sm.registeredAdapters() if a.provided == IMarkerAndAdapterBehavior][0]
     (<InterfaceClass zope.annotation.interfaces.IAnnotatable>,)
+
+
+6.2) non ``@adapter`` decorated Behavior implementation.
+
+    >>> dummy = getUtility(IBehavior, name=u"marker_and_adapter_no_atadapter")
+    >>> dummy.name
+    u'marker_and_adapter_no_atadapter'
+
+    >>> dummy.title
+    u'Marker and adapter no @adapter'
+
+    >>> dummy.description is None
+    True
+
+    >>> dummy.interface
+    <InterfaceClass plone.behavior.tests.IMarkerAndAdapterBehavior2>
+
+    >>> dummy.marker
+    <InterfaceClass plone.behavior.tests.IMarkerAndAdapterMarker2>
+
+    >>> dummy.factory # doctest: +ELLIPSIS
+    <class 'plone.behavior.tests.DummyBehaviorImpl'>
+
+    The factory has ist ``__component_adapts__`` (``@adapter``) in place, so the adapted Interface must be returned.
+
+    >>> from plone.behavior.tests import IMarkerAndAdapterBehavior2
+    >>> [a.required for a in sm.registeredAdapters() if a.provided == IMarkerAndAdapterBehavior2][0]
+    (<InterfaceClass plone.behavior.tests.IMarkerAndAdapterMarker2>,)
+
 
 7) A name only registered behavior
 

--- a/plone/behavior/interfaces.py
+++ b/plone/behavior/interfaces.py
@@ -85,7 +85,7 @@ class IBehaviorAdapterFactory(Interface):
     """
 
     behavior = schema.Object(
-        title=u"The behavior this is a factory for",
+        title=u'The behavior this is a factory for',
         schema=IBehavior
     )
 

--- a/plone/behavior/metaconfigure.py
+++ b/plone/behavior/metaconfigure.py
@@ -23,66 +23,92 @@ class IBehaviorDirective(Interface):
     """
 
     name = TextLine(
-        title=u"Name",
-        description=u"Convenience lookup name for this behavior",
+        title=u'Name',
+        description=u'Convenience lookup name for this behavior',
         required=False)
 
     title = configuration_fields.MessageID(
-        title=u"Title",
-        description=u"A user friendly title for this behavior",
+        title=u'Title',
+        description=u'A user friendly title for this behavior',
         required=True)
 
     description = configuration_fields.MessageID(
-        title=u"Description",
-        description=u"A longer description for this behavior",
+        title=u'Description',
+        description=u'A longer description for this behavior',
         required=False)
 
     provides = configuration_fields.GlobalInterface(
-        title=u"An interface to which the behavior can be adapted",
-        description=u"This is what the conditional adapter factory will "
-                    u"be registered as providing",
+        title=u'An interface to which the behavior can be adapted',
+        description=u'This is what the conditional adapter factory will '
+                    u'be registered as providing',
         required=True)
 
     marker = configuration_fields.GlobalInterface(
-        title=u"A marker interface to be applied by the behavior",
-        description=u"If factory is not given, then this is optional",
+        title=u'A marker interface to be applied by the behavior',
+        description=u'If factory is not given, then this is optional',
         required=False)
 
     factory = configuration_fields.GlobalObject(
-        title=u"The factory for this behavior",
-        description=u"If this is not given, the behavior is assumed to "
-                    u"provide a marker interface",
+        title=u'The factory for this behavior',
+        description=u'If this is not given, the behavior is assumed to '
+                    u'provide a marker interface',
         required=False)
 
     for_ = configuration_fields.GlobalObject(
-        title=u"The type of object to register the conditional adapter "
-              u"factory for",
-        description=u"This is optional - the default is to register the "
-                    u"factory for zope.interface.Interface",
+        title=u'The type of object to register the conditional adapter '
+              u'factory for',
+        description=u'This is optional - the default is to register the '
+                    u'factory for zope.interface.Interface',
         required=False)
 
     name_only = configuration_fields.Bool(
-        title=u"Do not register the behavior under the dotted path, but "
-              u"only under the given name",
-        description=u"Use this option to register a behavior for the same "
-                    u"provides under a different name.",
+        title=u'Do not register the behavior under the dotted path, but '
+              u'only under the given name',
+        description=u'Use this option to register a behavior for the same '
+                    u'provides under a different name.',
         required=False)
+
+
+def _detect_for(factory, marker):
+    """if no explicit for is given we need to figure it out.
+    """
+    # Attempt to guess the factory's adapted interface and use it as
+    # the 'for_'.
+    # at last bastion fallback to '*' (=Interface).
+    adapts = getattr(factory, '__component_adapts__', [])
+    if len(adapts) == 1:
+        return adapts[0]
+    if len(adapts) > 1:
+        raise ConfigurationError(
+            u'The factory can not be declared as multi-adapter.'
+        )
+    # down here it means len(adapts) < 1
+    if marker is not None:
+        # given we have a marker it is safe to register for the
+        # marker, as the behavior context will always provides it
+        return marker
+    # fallback: for="*"
+    return Interface
 
 
 def behaviorDirective(_context, title, provides, name=None, description=None,
                       marker=None, factory=None, for_=None, name_only=False):
 
     if marker is None and factory is None:
+        # a schema only behavior means usually direct attribute settings on the
+        # object itself, so the object itself provides the interface.
+        # so we mark with the provides.
         marker = provides
 
     if marker is not None and factory is None and marker is not provides:
         raise ConfigurationError(
-            u"You cannot specify a different 'marker' and 'provides' if "
-            u"there is no adapter factory for the provided interface."
+            u'You cannot specify a different \'marker\' and \'provides\' if '
+            u'there is no adapter factory for the provided interface.'
         )
     if name_only and name is None:
         raise ConfigurationError(
-            u"If you decide to only register by 'name', a name must be given."
+            u'If you decide to only register by \'name\', a name must '
+            u'be given.'
         )
 
     # Instantiate the real factory if it's the schema-aware type. We do
@@ -90,6 +116,7 @@ def behaviorDirective(_context, title, provides, name=None, description=None,
     if factory is not None and ISchemaAwareFactory.providedBy(factory):
         factory = factory(provides)
 
+    # the behavior registration hold all information about the behavior.
     registration = BehaviorRegistration(
         title=title,
         description=description,
@@ -98,6 +125,9 @@ def behaviorDirective(_context, title, provides, name=None, description=None,
         factory=factory,
         name=name,
     )
+    # the behavior registration can be looked up as a named utility.
+    # the name of the utility is either the full dotted path of the interface
+    # it provides...
     if not name_only:
         # behavior registration by provides interface identifier
         utility(
@@ -108,7 +138,10 @@ def behaviorDirective(_context, title, provides, name=None, description=None,
         )
 
     if name is not None:
-        # for convinience we register with a given name
+        # .. or if given, we register with a given (short) name.
+        # Advantage is, we can have more than one implementations of a
+        # behavior on one object (if a factory is used).
+        # This is handy for certain use cases.
         utility(
             _context,
             provides=IBehavior,
@@ -119,25 +152,16 @@ def behaviorDirective(_context, title, provides, name=None, description=None,
     if factory is None:
         if for_ is not None:
             logger.warn(
-                u"Specifying 'for' in behavior '{0}' if no 'factory' is given "
-                u"has no effect and is superfluous.".format(title)
+                u'Specifying \'for\' in behavior \'{0}\' if no \'factory\' is '
+                u'given has no effect and is superfluous.'.format(title)
             )
-        # w/o factory we're done here
+        # w/o factory we're done here: schema only behavior
         return
 
     if for_ is None:
-        # Attempt to guess the factory's adapted interface and use it as
-        # the 'for_'.
-        # Fallback to '*' (=Interface).
-        adapts = getattr(factory, '__component_adapts__', None) or [Interface]
-        if len(adapts) != 1:
-            raise ConfigurationError(
-                u"The factory can not be declared as multi-adapter."
-            )
-        for_ = adapts[0]
+        for_ = _detect_for(factory, marker)
 
     adapter_factory = BehaviorAdapterFactory(registration)
-
     adapter(
         _context,
         factory=(adapter_factory,),

--- a/plone/behavior/registration.py
+++ b/plone/behavior/registration.py
@@ -7,6 +7,7 @@ from zope.interface import implementer
 import sys
 import textwrap
 
+
 if sys.version_info[0] >= 3:
     text_type = str
 else:

--- a/plone/behavior/tests.py
+++ b/plone/behavior/tests.py
@@ -67,7 +67,7 @@ class INameOnlyBehavior(Interface):
 
 # For test of the annotation factory
 class IAnnotationStored(Interface):
-    some_field = schema.TextLine(title=u"Some field", default=u"default value")
+    some_field = schema.TextLine(title=u'Some field', default=u'default value')
 
 
 # Behavior and marker
@@ -75,8 +75,22 @@ class IMarkerAndAdapterBehavior(Interface):
     pass
 
 
+class IMarkerAndAdapterBehavior2(Interface):
+    pass
+
+
 class IMarkerAndAdapterMarker(Interface):
     pass
+
+
+class IMarkerAndAdapterMarker2(Interface):
+    pass
+
+
+class DummyBehaviorImpl(object):
+
+    def __init__(self, context):
+        self.context = context
 
 
 class Py23DocChecker(doctest.OutputChecker):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 
-version = '1.1.5.dev0'
+version = '1.2.0.dev0'
 desc = "Infrastructure for maintaining a registry of available behaviors"
 doc_files = [
     "README.rst",


### PR DESCRIPTION
For ZCML registration:
If both, no ``for`` and no ``@adapter`` is given (both explicit), implicit fall first back to ``marker`` if given (new),  else to ``Interface`` (as it was already before).

If given, ``marker `` is always provided by the context and makes the most sense to be adapted. It is a much better match than just ``Interface``.