### PR TITLE
Unify Python versions in setup.py, tox and Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: python
-sudo: false
 python:
     - 2.7
-    - 3.4
     - 3.5
     - 3.6
+    - 3.7
+    - 3.8
 install:
     - pip install tox-travis
 script:

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         "Framework :: Plone :: Core",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py27,py33,py34,py35
+    py27,py35,py36,py37,py38
 
 [testenv]
 deps =


### PR DESCRIPTION
Added 3.5 to setup.py classifiers.
Removed testing for 3.4 from Travis, added 3.7 and 3.8.
Removed testing for 3.3 and 3.4 from tox, added 3.6, 3.7 and 3.8.

No code change, so no news snippet.
And no Jenkins jobs needed.